### PR TITLE
Feature/134127 Incluir novo email na resposta de sucesso

### DIFF
--- a/apps/alteracao_email/api/views/alteracao_email_viewset.py
+++ b/apps/alteracao_email/api/views/alteracao_email_viewset.py
@@ -38,8 +38,11 @@ class ValidarAlteracaoEmailViewSet(viewsets.ViewSet):
     def update(self, request, pk=None):
 
         try:
-            AlteracaoEmailService.validar(pk)
-            return Response({"message": "E-mail alterado com sucesso."}, status=status.HTTP_200_OK)
+            usuario = AlteracaoEmailService.validar(pk)
+            return Response(
+                {"message": "E-mail alterado com sucesso.", "email": usuario.email},
+                status=status.HTTP_200_OK,
+            )
         
         except TokenJaUtilizadoException as e:
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/alteracao_email/tests/api/views/test_alteracao_email_viewset.py
+++ b/apps/alteracao_email/tests/api/views/test_alteracao_email_viewset.py
@@ -70,11 +70,12 @@ class TestValidarAlteracaoEmailViewSet:
         api_client.force_authenticate(user=user)
         pk = "123"
 
-        with patch.object(AlteracaoEmailService, "validar", return_value=None):
+        with patch.object(AlteracaoEmailService, "validar", return_value=user):
             response = api_client.put(f"{self.endpoint}{pk}/")
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["message"] == "E-mail alterado com sucesso."
+        assert response.data["email"] == user.email
 
     def test_update_token_ja_utilizado(self, api_client, user):
 


### PR DESCRIPTION
Este PR:


- Adiciona campo email no retorno
- Ajusta os testes para incluir o novo campo

Historia: [AB#132111](https://dev.azure.com/SME-Spassu/7e92ae7b-7c5d-42b3-8ccb-3229aa6f7d19/_workitems/edit/132111) e tarefa: [AB#134127](https://dev.azure.com/SME-Spassu/7e92ae7b-7c5d-42b3-8ccb-3229aa6f7d19/_workitems/edit/134127) 